### PR TITLE
fix target binary directory for Android

### DIFF
--- a/calculator-android/plugins/src/main/kotlin/org/rustylibs/plugins/UniFfiAndroidPlugin.kt
+++ b/calculator-android/plugins/src/main/kotlin/org/rustylibs/plugins/UniFfiAndroidPlugin.kt
@@ -120,15 +120,15 @@ internal class UniFfiAndroidPlugin : Plugin<Project> {
             into("${project.projectDir}/../lib/src/main/jniLibs/")
 
             into("arm64-v8a") {
-                from("${project.projectDir}/../../target/aarch64-linux-android/release/libcalculatorffi.so")
+                from("${project.projectDir}/../../calculator-ffi/target/aarch64-linux-android/release/libcalculatorffi.so")
             }
 
             into("x86_64") {
-                from("${project.projectDir}/../../target/x86_64-linux-android/release/libcalculatorffi.so")
+                from("${project.projectDir}/../../calculator-ffi/target/x86_64-linux-android/release/libcalculatorffi.so")
             }
 
             into("armeabi-v7a") {
-                from("${project.projectDir}/../../target/armv7-linux-androideabi/release/libcalculatorffi.so")
+                from("${project.projectDir}/../../calculator-ffi/target/armv7-linux-androideabi/release/libcalculatorffi.so")
             }
 
             doLast {

--- a/calculator-android/plugins/src/main/kotlin/org/rustylibs/plugins/UniFfiAndroidPlugin.kt
+++ b/calculator-android/plugins/src/main/kotlin/org/rustylibs/plugins/UniFfiAndroidPlugin.kt
@@ -120,15 +120,15 @@ internal class UniFfiAndroidPlugin : Plugin<Project> {
             into("${project.projectDir}/../lib/src/main/jniLibs/")
 
             into("arm64-v8a") {
-                from("${project.projectDir}/../../calculator-ffi/target/aarch64-linux-android/release/libcalculatorffi.so")
+                from("${project.projectDir}/../../calculator-ffi/target/aarch64-linux-android/release-smaller/libcalculatorffi.so")
             }
 
             into("x86_64") {
-                from("${project.projectDir}/../../calculator-ffi/target/x86_64-linux-android/release/libcalculatorffi.so")
+                from("${project.projectDir}/../../calculator-ffi/target/x86_64-linux-android/release-smaller/libcalculatorffi.so")
             }
 
             into("armeabi-v7a") {
-                from("${project.projectDir}/../../calculator-ffi/target/armv7-linux-androideabi/release/libcalculatorffi.so")
+                from("${project.projectDir}/../../calculator-ffi/target/armv7-linux-androideabi/release-smaller/libcalculatorffi.so")
             }
 
             doLast {


### PR DESCRIPTION
When I try to use the locally published Android library in mavenLocal in a new Android project, it's giving error that it cannot find libcalculatorffi.so. After investigation about the Gradle plugin, it seems currently the generated Kotlin bindings for Android does not include binary artifact in the calculator-android-0.1.0.aar file due to the wrong settings for target directory in UniFfiAndroidPlugin.kt. 
calculator-android uses the same Gradle plugin settings as the bdk-android for Android bindings, but in bdkffi the target directory was generated in the parent folder of bdk-android, unlike calculator-android which generates the target directory in calculator-ffi directory. 
This PR is to fix this issue.