### PR TITLE
add necessary environment variables for android plugin

### DIFF
--- a/calculator-android/plugins/src/main/kotlin/org/rustylibs/plugins/UniFfiAndroidPlugin.kt
+++ b/calculator-android/plugins/src/main/kotlin/org/rustylibs/plugins/UniFfiAndroidPlugin.kt
@@ -39,7 +39,9 @@ internal class UniFfiAndroidPlugin : Plugin<Project> {
 
                 Pair("CFLAGS", "-D__ANDROID_API__=21"),
                 Pair("CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER", "aarch64-linux-android21-clang"),
-                Pair("CC", "aarch64-linux-android21-clang")
+                Pair("CC", "aarch64-linux-android21-clang"),
+                Pair("AR", "llvm-ar"),
+                Pair("RANLIB", "llvm-ranlib")
             )
 
             doLast {
@@ -71,7 +73,9 @@ internal class UniFfiAndroidPlugin : Plugin<Project> {
 
                 Pair("CFLAGS", "-D__ANDROID_API__=21"),
                 Pair("CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER", "x86_64-linux-android21-clang"),
-                Pair("CC", "x86_64-linux-android21-clang")
+                Pair("CC", "x86_64-linux-android21-clang"),
+                Pair("AR", "llvm-ar"),
+                Pair("RANLIB", "llvm-ranlib")
             )
 
             doLast {
@@ -102,7 +106,9 @@ internal class UniFfiAndroidPlugin : Plugin<Project> {
 
                 Pair("CFLAGS", "-D__ANDROID_API__=21"),
                 Pair("CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER", "armv7a-linux-androideabi21-clang"),
-                Pair("CC", "armv7a-linux-androideabi21-clang")
+                Pair("CC", "armv7a-linux-androideabi21-clang"),
+                Pair("AR", "llvm-ar"),
+                Pair("RANLIB", "llvm-ranlib")
             )
 
             doLast {


### PR DESCRIPTION
I'm facing the below errors when using the default settings of Android Gradle plugin used in the template. After adding two more environment variables listed in https://developer.android.com/ndk/guides/other_build_systems, this issue was resolved.
It seems additional environment variables used in Android Gradle plugin is needed if we want to add any dependencies that talks to the internet like HTTP request. I'm not sure if it's appropriate to add it to this template.

This issue can be reproduced by using this graphql example that I created here:
https://github.com/aki-mizu/uniffi-bindings-template/tree/graphql-example

Inside the example
`reqwest = { version = "0.11", features = ["blocking", "json", "native-tls-vendored"] }`
was the dependency that caused this problem.

>   make[1]: aarch64-linux-android-ar: No such file or directory
  make[1]: *** [libssl.a] Error 1
  make[1]: *** Waiting for unfinished jobs....
  make: *** [build_libs] Error 2
  thread 'main' panicked at '
Error building OpenSSL:
      Command: cd "~/uniffi-bindings-template/calculator-ffi/target/aarch64-linux-android/release-smaller/build/openssl-sys-e20831ad92c248a7/out/openssl-build/build/src" && MAKEFLAGS="-j --jobserver-fds=7,13 --jobserver-auth=7,13" "make" "build_libs"
      Exit status: exit status: 2
      ~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/openssl-src-111.27.0+1.1.1v/src/lib.rs:506:13
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
> Task :lib:buildAndroidAarch64Binary FAILED
FAILURE: Build failed with an exception.